### PR TITLE
[개선] 개발용 RDS 설정

### DIFF
--- a/config/db.js
+++ b/config/db.js
@@ -1,27 +1,9 @@
 const fs = require('fs');
 const dbKey = fs.readFileSync('key/dbKey', 'utf-8').replace(/\n/g, '');
-
-// module.exports = function(){
-//   const mysql = require('mysql');
-
-//   const conn = mysql.createConnection({
-//     host : 'smusmutest.cew1lcmxgnch.ap-northeast-2.rds.amazonaws.com',
-//     user : 'smusmu',
-//     password : dbKey,
-//     database : 'smusmutest',
-//     dateStrings: 'date',
-//     charset : 'utf8mb4'
-//   })
-
-//   conn.connect();
-//   return conn;
-// }
-
-
 const mysql = require('mysql');
 
 const conn = mysql.createConnection({
-  host: 'smusmu.ckkukgt0dpwr.ap-northeast-2.rds.amazonaws.com',
+  host: 'smusmu-dev.c5smsp2kymwd.ap-northeast-2.rds.amazonaws.com',
   user: 'smusmu',
   password: dbKey,
   database: 'smusmutest',

--- a/config/express.js
+++ b/config/express.js
@@ -34,7 +34,7 @@ module.exports = function () {
     resave: false,
     saveUninitialized: true,
     store: new MySQLSessionStore({
-      host: 'smusmu.ckkukgt0dpwr.ap-northeast-2.rds.amazonaws.com',
+      host: 'smusmu-dev.c5smsp2kymwd.ap-northeast-2.rds.amazonaws.com',
       port: 3306,
       user: 'smusmu',
       password: dbKey,


### PR DESCRIPTION
#45 PR 입니다.

# 변경사항
- db rds endpoint 변경

# 참고
webpack4을 도입해야지 config를 자동화 할수 있습니다.
즉, 구동환경별 DB 접속을 달리하는것은 webpack4를 도입한 후 적용하겠습니다~
일단 한동안은 real RDS로 접속은 하지 않고 개발용 RDS로만 접속하도록 수정합니다.

추후 webpack 도입 후 명령어에 따라 DB 접속 정보를 구분할 수 있도록 하겠습니다 ㅠ